### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/scripts/cv_object_detection.py
+++ b/scripts/cv_object_detection.py
@@ -9,6 +9,11 @@ import ImageChops
 # make sure to get opencv 3.4 and up
 # pip3.7 install opencv-contrib-python
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 # Motion detection flow
 
 # The cutoff for threshold. A lower number means smaller changes between


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/dnn-object-detection on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./scripts/cv_object_detection.py:222:22: F821 undefined name 'xrange'
            for i in xrange(len(tracked_blobs) - 1, -1, -1):
                     ^
1     F821 undefined name 'xrange'
1
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
